### PR TITLE
Увеличиваем макимальное количество возможных кнопок до 8 для ESP32

### DIFF
--- a/include/Consts.h
+++ b/include/Consts.h
@@ -46,7 +46,13 @@
 #define MYSENSORS
 #endif
 
+#ifndef esp32_4mb
 #define NUM_BUTTONS 6
+#endif
+#ifdef esp32_4mb
+#define NUM_BUTTONS 8
+#endif
+
 #define MQTT_RECONNECT_INTERVAL 20000
 #define CHANGE_BROKER_AFTER 5
 #define TELEMETRY_UPDATE_INTERVAL_MIN 60


### PR DESCRIPTION
6 кнопок для ESP32 маловато, 8 - это два блока клавиш света по 4 кнопки.