### PR TITLE
Исправляем ошибку чтения температуры для Dallas на ESP32 и добавляем адресацию

### DIFF
--- a/include/Utils/StringUtils.h
+++ b/include/Utils/StringUtils.h
@@ -2,6 +2,10 @@
 
 #include <Arduino.h>
 
+void hex2string(byte array[], unsigned int len, char buffer[]);
+
+int string2hex(const char* str, unsigned char* bytes );
+
 uint8_t hexStringToUint8(String hex);
 
 uint16_t hexStringToUint16(String hex);

--- a/include/items/vSensorDallas.h
+++ b/include/items/vSensorDallas.h
@@ -5,17 +5,19 @@
 #include <DallasTemperature.h>
 #include "Global.h"
 
-
+//ИНТЕГРИРУЮ: Объявляем глагольные переменные необходимые интегрируемой библиотеке
 extern DallasTemperature sensors;
 extern OneWire* oneWire;
 
+//ИНТЕГРИРУЮ: следим за наименованиями далее
 class SensorDallas;
 
 typedef std::vector<SensorDallas> MySensorDallasVector;
 
 class SensorDallas {
    public:
-    SensorDallas(unsigned long interval, unsigned int pin, unsigned int index, String key);
+   //ИНТЕГРИРУЮ: обращаем внимание на параметры, берутся из таблицы настроек
+    SensorDallas(unsigned long interval, unsigned int pin, unsigned int index, String addr, String key);
     ~SensorDallas();
 
     void loop();
@@ -27,6 +29,7 @@ class SensorDallas {
     unsigned long difference;
     unsigned long _interval;
     String _key;
+    String _addr;
     unsigned int _pin;
     unsigned int _index;
 };

--- a/src/BufferExecute.cpp
+++ b/src/BufferExecute.cpp
@@ -100,6 +100,7 @@ void csvCmdExecute(String& cmdStr) {
 #ifdef EnableSensorUltrasonic
                 sCmd.addCommand(order.c_str(), ultrasonic);
 #endif
+//ИНТЕГРИРУЮ: Первая интеграция в ядро. Следим за наименованием
             } else if (order == F("dallas-temp")) {
 #ifdef EnableSensorDallas
                 sCmd.addCommand(order.c_str(), dallas);

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -163,6 +163,7 @@ void clearVectors() {
     pwmOut_EnterCounter = -1;
 #endif
     //==================================
+    //ИНТЕГРИРУЮ: Вторая интеграция в ядро. Следим за наименованием
 #ifdef EnableSensorDallas
     if (mySensorDallas2 != nullptr) {
         mySensorDallas2->clear();

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -62,6 +62,41 @@ String selectFromMarkerToMarker(String str, String tofind, int number) {
     return "not found";
 }
 
+//преобразовываем байтовый массив в человеческий вид HEX в строке
+void hex2string(byte array[], unsigned int len, char buffer[])
+{
+    for (unsigned int i = 0; i < len; i++)
+    {
+        byte nib1 = (array[i] >> 4) & 0x0F;
+        byte nib2 = (array[i] >> 0) & 0x0F;
+        buffer[i*2+0] = nib1  < 0xA ? '0' + nib1  : 'A' + nib1  - 0xA;
+        buffer[i*2+1] = nib2  < 0xA ? '0' + nib2  : 'A' + nib2  - 0xA;
+    }
+    buffer[len*2] = '\0';
+}
+
+inline unsigned char ChartoHex( char ch )
+{
+   return ( ( ch >= 'A' ) ? ( ch - 'A' + 0xA ) : ( ch - '0' ) ) & 0x0F;
+}
+
+// str   - указатель на массив символов
+// bytes - выходной буфер
+// функция возвращает колл-во байт
+//
+int string2hex(const char* str, unsigned char* bytes ) 
+{
+   unsigned char Hi, Lo;
+
+   int i = 0;
+   while( ( Hi = *str++ ) && ( Lo = *str++ ) )
+   {
+      bytes[i++] = ( ChartoHex( Hi ) << 4 ) | ChartoHex( Lo ); 
+   }
+
+   return i;
+}
+
 uint8_t hexStringToUint8(String hex) {
     uint8_t tmp = strtol(hex.c_str(), NULL, 0);
     if (tmp >= 0x00 && tmp <= 0xFF) {

--- a/src/items/vSensorDallas.cpp
+++ b/src/items/vSensorDallas.cpp
@@ -4,26 +4,38 @@
 #include "BufferExecute.h"
 #include "Class/LineParsing.h"
 #include "Global.h"
+#include "DallasTemperature.h"
+#include "Utils/StringUtils.h"
 
 #include <Arduino.h>
 
+//ИНТЕГРИРУЮ: переменные необходимые для работы интегрируемой библиотеки. Аналог Arduino
 OneWire* oneWire;
 DallasTemperature sensors;
 
-SensorDallas::SensorDallas(unsigned long interval, unsigned int pin, unsigned int index, String key) {
+//ИНТЕГРИРУЮ:
+//Для каждого датчика указанного в конфигурации вызывается конструктор для настройки перед запуском. Аналог функции setup() в Arduino.
+//В параметрах передаются дополнительные настройки, указанные все в той же таблице настройки устройства.
+SensorDallas::SensorDallas(unsigned long interval, unsigned int pin, unsigned int index, String addr, String key) {
+    //все особые параметры сливаем в локальные переменные экземпляра для будущего доступа
     _interval = interval * 1000;
     _key = key;
     _pin = pin;
     _index = index;
+    _addr = addr;
 
+    //ИНТЕГРИРУЮ: 
+    //вызываем необходимые инициирующие функции интегрируемой библиотеки
     oneWire = new OneWire((uint8_t)_pin);
     sensors.setOneWire(oneWire);
     sensors.begin();
     sensors.setResolution(12);
 }
 
+//ИНТЕГРИРУЮ: оставляем как есть или развиваем, если нужно правильно завершить работу с интегрируемой библиотекой после отключения датчика
 SensorDallas::~SensorDallas() {}
 
+//ИНТЕГРИРУЮ: аналог loop() в Arduino. Требуется изменить, если интегрируемая библиотека нуждается в другом алгоритме квотирования времени.
 void SensorDallas::loop() {
     currentMillis = millis();
     difference = currentMillis - prevMillis;
@@ -33,34 +45,52 @@ void SensorDallas::loop() {
     }
 }
 
+//ИНТЕГРИРУЮ: вызывается из цикла loop каждый установленный временно интервал в параметрах датчика. Необходимо изменить для чтения данных из датчика.
 void SensorDallas::readDallas() {
-    sensors.requestTemperaturesByIndex(_index);
-    float value = sensors.getTempCByIndex(_index);
+    //запускаем опрос измерений у всех датчиков на линии
+    sensors.requestTemperatures();
+    
+    //Определяем адрес. Если парамтер addr не установлен, то узнаем адрес по индексу
+    DeviceAddress deviceAddress;
+    if (_addr == "") {
+        sensors.getAddress(deviceAddress, _index);
+    } else {
+        string2hex(_addr.c_str(), deviceAddress);
+    }
+
+    //получаем температуру по адресу
+    float value = sensors.getTempC(deviceAddress);
+    
+    //ИНТЕГРИРУЮ: блок генерации уведомлений в ядре системы. Стоит обратить внимание только на формат выводимого сообщения в консоли. 
     eventGen2(_key, String(value));
     jsonWriteStr(configLiveJson, _key, String(value));
     publishStatus(_key, String(value));
-         String path = mqttRootDevice + "/" +_key + "/status";
-    String json = "{}";
-    jsonWriteStr(json, "status", String(value));
-    String MyJson = json; 
-    jsonWriteStr(MyJson, "topic", path); 
-    ws.textAll(MyJson);
-    SerialPrint("I", "Sensor", "'" + _key + "' data: " + String(value));
+    char addrStr[20] = "";
+    hex2string(deviceAddress, 8, addrStr); 
+    SerialPrint("I", "Sensor", "'" + _key + "' data: " + String(value) + "' addr: " + String(addrStr));
 }
 
+//ИНТЕГРИРУЮ: глобальная переменная необходима для интеграции в ядро. Следим за наименованием.
 MySensorDallasVector* mySensorDallas2 = nullptr;
 
+//ИНТЕГРИРУЮ: функция вызывается ядром для каждой записи в таблице настроки для создания экземпляров датчиков
+//некоторые датчики записаны в таблице в виде нескольких строк, поэтому необходимо контролировать итерации обращения к данной функции
 void dallas() {
+    //ИНТЕГРИРУЮ: не меняем
     myLineParsing.update();
+    //ИНТЕГРИРУЮ: устанавливаем в соответствии с параметрами таблицы
     String interval = myLineParsing.gint();
     String pin = myLineParsing.gpin();
     String index = myLineParsing.gindex();
     String key = myLineParsing.gkey();
+    String addr = myLineParsing.gaddr();
+    //ИНТЕГРИРУЮ: не меняем
     myLineParsing.clear();
 
+    //ИНТЕГРИРУЮ: блок создания экземпляров датчиков. Обратить внимание на наименования и передаваемые параметры в конструктор
     static bool firstTime = true;
     if (firstTime) mySensorDallas2 = new MySensorDallasVector();
     firstTime = false;
-    mySensorDallas2->push_back(SensorDallas(interval.toInt(), pin.toInt(), index.toInt(), key));
+    mySensorDallas2->push_back(SensorDallas(interval.toInt(), pin.toInt(), index.toInt(), addr, key));
 }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,6 +138,7 @@ void loop() {
         }
     }
 #endif
+//ИНТЕГРИРУЮ: Третья интеграция в ядро. Следим за наименованием
 #ifdef EnableLogging
     if (myLogging != nullptr) {
         for (unsigned int i = 0; i < myLogging->size(); i++) {


### PR DESCRIPTION
Устранил ошибку чтения температуры для ESP32 и добавил возможность указывать адрес для каждого датчика. Это повышает отказоустойчивость системы по сравнению с вариантом использования индексов. В параметрах вместо index[0] нужно указать addr[FFх8], например, addr[AE43A43851237BDD]. Адрес берем из терминала.
Дополнительно прокомментировал важные строки и места в коде для желающих добавить свой датчик. Ключевое слово для поиска по дереву проекта: "//ИНТЕГРИРУЮ:"